### PR TITLE
Level 8 load game fix; Toa classes simplified a bit

### DIFF
--- a/OSIProject/OSIProject.osiproj
+++ b/OSIProject/OSIProject.osiproj
@@ -6,7 +6,10 @@
   </PropertyGroup>
   <Import Project="$(CustomProjectExtensionsPath)OSIProject.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputDirectory>C:\Program Files (x86)\LEGO Media\LEGO Bionicle (Beta)\data</OutputDirectory>
+    <OutputDirectory>C:\Program Files (x86)\LEGO Media\LEGO Bionicle (Beta)\LEGO Bionicle (Optional)\data</OutputDirectory>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <OutputDirectory>C:\Program Files (x86)\LEGO Media\LEGO Bionicle (Beta)\LEGO Bionicle (Optional)\data</OutputDirectory>
   </PropertyGroup>
   <ItemGroup>
     <OSIAssembly Include="**\*.osa" />


### PR DESCRIPTION
Should be good to go; code changes here appear to be fully stable and have no negative effects that have been seen.  

These commits should do the following:
- Make Lewa and Nobua more compatible with Toa swapping.
- Fixed Front End crashing when attempting to load a saved game from level 8.
- Added texture path for Nobua image to be displayed on Front End load game menu.
- Some cleanup of redundant/dead subroutines.
